### PR TITLE
fix: Unwrap data in documentTypes.get() and rename schema → jsonSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-05-07
+
+### Fixed
+
+- `client.documentTypes.get(id)` now correctly unwraps the `{ data }` envelope returned by `GET /api/document-types/:id` and returns a flat `DocumentType`. Previously the wrapper leaked through, causing every field to read as `undefined` despite the declared type. Aligns `get()` with the pattern already used by `create()` and `update()`.
+
+### Changed
+
+- **Breaking (type-only):** `DocumentType.schema` renamed to `DocumentType.jsonSchema` to match the API wire format and the `jsonSchema` field already used in `DocumentTypeCreateParams` and `DocumentTypeUpdateParams`. The runtime field never arrived under the old name, so no real consumer is affected, but TypeScript code reading `.schema` will need to update to `.jsonSchema`.
+
 ## [0.1.2] - 2026-04-07
 
 ### Added

--- a/examples/document-types.ts
+++ b/examples/document-types.ts
@@ -40,7 +40,7 @@ async function getDocumentType(id: string) {
   console.log('Name:', dt.name);
   console.log('Code:', dt.codeType);
   console.log('Description:', dt.description);
-  console.log('Schema:', JSON.stringify(dt.schema, null, 2));
+  console.log('Schema:', JSON.stringify(dt.jsonSchema, null, 2));
 }
 
 async function validateDocumentType(id: string) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docutray",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Node.js library for the DocuTray API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/resources/document-types.ts
+++ b/src/resources/document-types.ts
@@ -53,10 +53,11 @@ export class DocumentTypes extends APIResource {
    * @returns The document type definition.
    */
   async get(id: string, options?: Omit<RequestOptions, 'raw'>): Promise<DocumentType> {
-    return this._client.get<DocumentType>(
+    const response = await this._client.get<{ data: DocumentType }>(
       `/api/document-types/${id}`,
       options,
-    ) as Promise<DocumentType>;
+    ) as { data: DocumentType };
+    return response.data;
   }
 
   /**

--- a/src/types/document-type.ts
+++ b/src/types/document-type.ts
@@ -20,8 +20,8 @@ export interface DocumentType {
   createdAt: string | null;
   /** ISO 8601 last-updated timestamp. */
   updatedAt: string | null;
-  /** The extraction schema definition. */
-  schema: Record<string, unknown> | null;
+  /** The JSON Schema defining the extraction structure. */
+  jsonSchema: Record<string, unknown> | null;
 }
 
 /**

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -71,7 +71,7 @@ export const mockDocumentType: DocumentType = {
   status: 'active',
   createdAt: '2025-01-01T00:00:00Z',
   updatedAt: '2025-01-01T00:00:00Z',
-  schema: { fields: ['total', 'date'] },
+  jsonSchema: { fields: ['total', 'date'] },
 };
 
 export const mockDocumentTypeCreated: DocumentType = {
@@ -84,7 +84,7 @@ export const mockDocumentTypeCreated: DocumentType = {
   status: 'draft',
   createdAt: '2025-06-01T00:00:00Z',
   updatedAt: '2025-06-01T00:00:00Z',
-  schema: { fields: ['total', 'merchant'] },
+  jsonSchema: { fields: ['total', 'merchant'] },
 };
 
 export const mockValidationResult: ValidationResult = {

--- a/tests/integration/pagination.test.ts
+++ b/tests/integration/pagination.test.ts
@@ -14,9 +14,10 @@ function makePage(page: number, limit: number, total: number) {
       description: `Document type ${start + i + 1}`,
       isPublic: true,
       isDraft: false,
+      status: 'active',
       createdAt: '2025-01-01T00:00:00Z',
       updatedAt: '2025-01-01T00:00:00Z',
-      schema: null,
+      jsonSchema: null,
     });
   }
   return {

--- a/tests/integration/retry.test.ts
+++ b/tests/integration/retry.test.ts
@@ -12,7 +12,7 @@ describe('Integration: Retry', () => {
         if (attempt === 1) {
           return HttpResponse.json({ message: 'Internal error' }, { status: 500 });
         }
-        return HttpResponse.json(mockDocumentType);
+        return HttpResponse.json({ data: mockDocumentType });
       }),
     );
 

--- a/tests/integration/timeout-cancellation.test.ts
+++ b/tests/integration/timeout-cancellation.test.ts
@@ -8,7 +8,7 @@ describe('Integration: Timeout & Cancellation', () => {
     server.use(
       http.get(`${TEST_BASE_URL}/api/document-types/dt-1`, async () => {
         await new Promise((resolve) => setTimeout(resolve, 500));
-        return HttpResponse.json(mockDocumentType);
+        return HttpResponse.json({ data: mockDocumentType });
       }),
     );
 
@@ -22,7 +22,7 @@ describe('Integration: Timeout & Cancellation', () => {
     server.use(
       http.get(`${TEST_BASE_URL}/api/document-types/dt-1`, async () => {
         await new Promise((resolve) => setTimeout(resolve, 5000));
-        return HttpResponse.json(mockDocumentType);
+        return HttpResponse.json({ data: mockDocumentType });
       }),
     );
 

--- a/tests/resources/document-types.test.ts
+++ b/tests/resources/document-types.test.ts
@@ -84,10 +84,10 @@ describe('DocumentTypes', () => {
   });
 
   describe('get()', () => {
-    it('fetches a document type by id', async () => {
+    it('fetches a document type by id and unwraps response', async () => {
       server.use(
         http.get(`${TEST_BASE_URL}/api/document-types/dt-789`, () => {
-          return HttpResponse.json(mockDocumentType);
+          return HttpResponse.json({ data: mockDocumentType });
         }),
       );
 
@@ -96,6 +96,8 @@ describe('DocumentTypes', () => {
 
       expect(result.id).toBe('dt-789');
       expect(result.name).toBe('Invoice');
+      expect(result.codeType).toBe('invoice');
+      expect(result.jsonSchema).toEqual({ fields: ['total', 'date'] });
     });
   });
 
@@ -189,7 +191,7 @@ describe('DocumentTypes', () => {
     it('returns RawResponse for get()', async () => {
       server.use(
         http.get(`${TEST_BASE_URL}/api/document-types/dt-789`, () => {
-          return HttpResponse.json(mockDocumentType);
+          return HttpResponse.json({ data: mockDocumentType });
         }),
       );
 


### PR DESCRIPTION
Closes #19

## Summary

- Fix `documentTypes.get(id)` to unwrap the `{ data }` envelope returned by `GET /api/document-types/:id`. Previously the raw wrapper leaked through and every field on the returned `DocumentType` read as `undefined`, despite TypeScript saying otherwise. Aligns the method with the unwrap pattern already used by `create()` and `update()`.
- Rename `DocumentType.schema` → `DocumentType.jsonSchema` to match the API wire format and the existing `jsonSchema` field on `DocumentTypeCreateParams` / `DocumentTypeUpdateParams`. Type-only breaking change; pre-1.0 patch release.
- Update the `get()` test and the integration retry/timeout/pagination fixtures to mock the real wire format (`{ data: ... }`). The old test mocked the already-unwrapped shape, which is why this bug went undetected for two minor versions.
- Bump version to `0.1.3` and document both changes in `CHANGELOG.md`.

The backend dependency (docutray/docutray#710 — `jsonSchema` in the GET response) is already merged, so this fix is fully unblocked.

## Acceptance criteria

- [x] `documentTypes.get(id)` returns a flat `DocumentType` (no `data` wrapper).
- [x] `DocumentType.jsonSchema` replaces `DocumentType.schema`.
- [x] Test mocks the real wire format and asserts the unwrapped result, including `jsonSchema`. Same fixture update applied to integration tests in `retry.test.ts`, `timeout-cancellation.test.ts`, and `pagination.test.ts`.
- [x] `npm run typecheck`, `npm run lint`, `npm test` (194 passing), `npm run build` all green.
- [x] CHANGELOG `[0.1.3]` describes the runtime fix and the type-only breaking change.
- [x] Version bumped to `0.1.3`.

## Test plan

- [x] Unit: `tests/resources/document-types.test.ts` — `get()` mocks `{ data: ... }` and asserts unwrapped fields including `jsonSchema`.
- [x] Integration: retry, timeout, pagination tests pass against updated mocks.
- [x] Full suite: 194/194 passing.
- [ ] Smoke test in downstream `@docutray/cli` once published — verify `types get` and `types export` no longer render `undefined`.

## Out of scope (follow-up)

The same `_client.get<T>(...)` pattern without unwrap exists in `KnowledgeBases.get` (`src/resources/knowledge-bases.ts:139`) and `Steps.getStatus` (`src/resources/steps.ts:70`, `:144`). Those need to be audited against the backend in a separate issue — flagged in the parent issue #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)