### PR TITLE
feat(types): expose conversionMode on DocumentType

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -112,6 +112,7 @@ export type {
   IdentificationStatus,
   IdentifyParams,
   DocumentType,
+  ConversionMode,
   ValidationErrorInfo,
   ValidationWarningInfo,
   ValidationResult,

--- a/src/types/document-type.ts
+++ b/src/types/document-type.ts
@@ -1,4 +1,9 @@
 /**
+ * Conversion mode used when extracting from a document type.
+ */
+export type ConversionMode = 'json' | 'toon' | 'multi_prompt';
+
+/**
  * A document type definition from the API.
  */
 export interface DocumentType {
@@ -22,6 +27,8 @@ export interface DocumentType {
   updatedAt: string | null;
   /** The JSON Schema defining the extraction structure. */
   jsonSchema: Record<string, unknown> | null;
+  /** Conversion mode used when extracting from this document type. */
+  conversionMode?: ConversionMode;
 }
 
 /**
@@ -73,7 +80,7 @@ export interface DocumentTypeCreateParams {
   /** Hints to guide the identification prompt. */
   identifyPromptHints?: string;
   /** The conversion mode to use. */
-  conversionMode?: 'json' | 'toon' | 'multi_prompt';
+  conversionMode?: ConversionMode;
   /** Whether to preserve property ordering in extraction output. */
   keepPropertyOrdering?: boolean;
   /** Whether the document type is publicly available. */
@@ -97,7 +104,7 @@ export interface DocumentTypeUpdateParams {
   /** Updated identification prompt hints. */
   identifyPromptHints?: string;
   /** Updated conversion mode. */
-  conversionMode?: 'json' | 'toon' | 'multi_prompt';
+  conversionMode?: ConversionMode;
   /** Whether to preserve property ordering. */
   keepPropertyOrdering?: boolean;
   /** Whether the document type is publicly available. */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,6 +37,7 @@ export {
 
 // Document type types
 export type {
+  ConversionMode,
   DocumentType,
   DocumentTypeCreateParams,
   DocumentTypeUpdateParams,

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -72,6 +72,7 @@ export const mockDocumentType: DocumentType = {
   createdAt: '2025-01-01T00:00:00Z',
   updatedAt: '2025-01-01T00:00:00Z',
   jsonSchema: { fields: ['total', 'date'] },
+  conversionMode: 'json',
 };
 
 export const mockDocumentTypeCreated: DocumentType = {
@@ -85,6 +86,7 @@ export const mockDocumentTypeCreated: DocumentType = {
   createdAt: '2025-06-01T00:00:00Z',
   updatedAt: '2025-06-01T00:00:00Z',
   jsonSchema: { fields: ['total', 'merchant'] },
+  conversionMode: 'multi_prompt',
 };
 
 export const mockValidationResult: ValidationResult = {

--- a/tests/resources/document-types.test.ts
+++ b/tests/resources/document-types.test.ts
@@ -3,6 +3,7 @@ import { server, http, HttpResponse } from '../helpers/mock-server.js';
 import { DocumentTypes } from '../../src/resources/document-types.js';
 import { APIClient } from '../../src/core/api-client.js';
 import { RawResponse } from '../../src/core/raw-response.js';
+import type { ConversionMode } from '../../src/types/document-type.js';
 import {
   TEST_BASE_URL,
   mockDocumentType,
@@ -113,7 +114,7 @@ describe('DocumentTypes', () => {
       const dt = createDocumentTypes();
       const result = await dt.get('dt-789');
 
-      const mode: 'json' | 'toon' | 'multi_prompt' | undefined = result.conversionMode;
+      const mode: ConversionMode | undefined = result.conversionMode;
       expect(mode).toBe('toon');
     });
   });

--- a/tests/resources/document-types.test.ts
+++ b/tests/resources/document-types.test.ts
@@ -98,6 +98,23 @@ describe('DocumentTypes', () => {
       expect(result.name).toBe('Invoice');
       expect(result.codeType).toBe('invoice');
       expect(result.jsonSchema).toEqual({ fields: ['total', 'date'] });
+      expect(result.conversionMode).toBe('json');
+    });
+
+    it('exposes conversionMode without requiring a cast', async () => {
+      server.use(
+        http.get(`${TEST_BASE_URL}/api/document-types/dt-789`, () => {
+          return HttpResponse.json({
+            data: { ...mockDocumentType, conversionMode: 'toon' },
+          });
+        }),
+      );
+
+      const dt = createDocumentTypes();
+      const result = await dt.get('dt-789');
+
+      const mode: 'json' | 'toon' | 'multi_prompt' | undefined = result.conversionMode;
+      expect(mode).toBe('toon');
     });
   });
 


### PR DESCRIPTION
## Summary

Adds the `conversionMode` field to the `DocumentType` response type so consumers no longer need to cast results to read it. The API already returns the field and `DocumentTypeCreateParams` / `DocumentTypeUpdateParams` already accept it — this fixes the input/output asymmetry called out in #21.

## Changes

- Extract a shared `ConversionMode = 'json' | 'toon' | 'multi_prompt'` type and reuse it across `DocumentType`, `DocumentTypeCreateParams`, and `DocumentTypeUpdateParams`.
- Re-export `ConversionMode` from the public entrypoints (`src/types/index.ts`, `src/index.ts`).
- Update mock fixtures to include `conversionMode`.

## Tests

- Added a regression test in `tests/resources/document-types.test.ts` verifying `conversionMode` is exposed on the typed result without a cast.
- `npm run typecheck`, `npm run lint`, `npm test` (195 passed), `npm run build` all pass.

## Linked Issue

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)