### PR TITLE
chore(release): 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-05-07
+
+### Added
+
+- `conversionMode` field on `DocumentType` so consumers can read it directly from API responses without casting (closes #21).
+- New exported `ConversionMode` type (`'json' | 'toon' | 'multi_prompt'`), shared across `DocumentType`, `DocumentTypeCreateParams`, and `DocumentTypeUpdateParams`.
+
 ## [0.1.3] - 2026-05-07
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docutray",
-  "version": "0.1.0",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docutray",
-      "version": "0.1.0",
+      "version": "0.1.4",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.0",
@@ -21,7 +21,7 @@
         "vitest": "^4.0.18"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@andrewbranch/untar.js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docutray",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Node.js library for the DocuTray API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

Release 0.1.4 — exposes `conversionMode` on `DocumentType` and adds a public `ConversionMode` type export (#21, merged in #22).

## Changes

- Bump `version` to `0.1.4` in `package.json` and `package-lock.json`
- Add `0.1.4` entry to `CHANGELOG.md`

## Release flow

After merge:
1. Tag `v0.1.4` on `main`
2. Create the GitHub release — this triggers `.github/workflows/publish.yml` (OIDC trusted publishing to npm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)