### PR TITLE
chore(release): 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-08-11
+
+### Added
+
+- `conversionSpec` field on `DocumentType`, `DocumentTypeCreateParams`, and `DocumentTypeUpdateParams` — the mapping from extracted JSON to CSV/Excel columns used by tray export, now exposed by the API on `GET`/`POST`/`PUT /api/document-types` (docutray/docutray#972). Optional, because list responses do not carry it.
+- New exported conversion-spec types: `ConversionSpec` (the union), `ConversionSpecColumn`, `ConversionSpecSheet`, `LegacyConversionSpec` (top-level `columns`), and `MultiSheetConversionSpec` (top-level `sheets`).
+- New exported `isMultiSheetConversionSpec(spec)` type guard, which narrows the union and accepts `null`/`undefined` so it can be called directly on `DocumentType.conversionSpec`.
+
+### Notes
+
+- Omitting `conversionSpec` on update leaves the stored spec unchanged; passing `null` clears it. When forwarding a spec read from a `DocumentType`, pass it through as-is (`{ conversionSpec: docType.conversionSpec }`) — do **not** normalize with `?? null`, which would turn the absent field of a `list()` result into a request to clear the stored spec.
+- Conversion specs are validated server-side only; a structurally invalid spec is rejected with `BadRequestError` and nothing is persisted.
+- Requires an API deployment including docutray/docutray#972. Older deployments omit the field on read and ignore it on write.
+
 ## [0.1.4] - 2026-05-07
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docutray",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docutray",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docutray",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Node.js library for the DocuTray API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Release PR for **0.1.5**, following the same shape as #23.

## Changes

- `package.json` / `package-lock.json`: `0.1.4` → `0.1.5`
- `CHANGELOG.md`: new `[0.1.5]` section

## Contents of this release

#24 — exposes `conversionSpec` on document types:

- `conversionSpec` on `DocumentType`, `DocumentTypeCreateParams` and `DocumentTypeUpdateParams`
- New exported types: `ConversionSpec`, `ConversionSpecColumn`, `ConversionSpecSheet`, `LegacyConversionSpec`, `MultiSheetConversionSpec`
- New exported `isMultiSheetConversionSpec(spec)` type guard

Purely additive — no breaking changes, hence the patch bump (same call as 0.1.3 → 0.1.4 for the analogous `conversionMode` addition).

## After merge

Publishing is driven by `publish.yml` on a released `v*` tag, so this needs a GitHub release `v0.1.5` created after merge to reach npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)